### PR TITLE
Add cost calculation functionality to Claudeee

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 require (
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.10.1
+	github.com/google/uuid v1.6.0
 	github.com/marcboeker/go-duckdb v1.8.5
 )
 
@@ -21,7 +22,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/flatbuffers v25.1.24+incompatible // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -16,6 +16,7 @@ type Session struct {
 	MessageCount     int       `json:"message_count" db:"message_count"`
 	Status           string    `json:"status" db:"status"`
 	CreatedAt        time.Time `json:"created_at" db:"created_at"`
+	TotalCost        float64   `json:"total_cost" db:"total_cost"`
 }
 
 type Message struct {
@@ -48,6 +49,7 @@ type TokenUsage struct {
 	WindowStart      time.Time `json:"window_start"`
 	WindowEnd        time.Time `json:"window_end"`
 	ActiveSessions   int     `json:"active_sessions"`
+	TotalCost        float64 `json:"total_cost"`
 }
 
 type SessionSummary struct {

--- a/backend/internal/services/cost_calculator.go
+++ b/backend/internal/services/cost_calculator.go
@@ -1,0 +1,167 @@
+package services
+
+import (
+	"strings"
+)
+
+// PricingCalculator provides cost calculation for Claude models
+type PricingCalculator struct {
+	pricing map[string]map[string]float64
+}
+
+// NewPricingCalculator creates a new pricing calculator with fallback pricing
+func NewPricingCalculator() *PricingCalculator {
+	// Fallback pricing per million tokens (USD)
+	fallbackPricing := map[string]map[string]float64{
+		"opus": {
+			"input":          15.0,
+			"output":         75.0,
+			"cache_creation": 18.75,
+			"cache_read":     1.5,
+		},
+		"sonnet": {
+			"input":          3.0,
+			"output":         15.0,
+			"cache_creation": 3.75,
+			"cache_read":     0.3,
+		},
+		"haiku": {
+			"input":          0.25,
+			"output":         1.25,
+			"cache_creation": 0.3,
+			"cache_read":     0.03,
+		},
+	}
+
+	// Map specific model names to pricing
+	pricing := map[string]map[string]float64{
+		"claude-3-opus":               fallbackPricing["opus"],
+		"claude-3-sonnet":             fallbackPricing["sonnet"],
+		"claude-3-haiku":              fallbackPricing["haiku"],
+		"claude-3-5-sonnet":           fallbackPricing["sonnet"],
+		"claude-3-5-haiku":            fallbackPricing["haiku"],
+		"claude-sonnet-4-20250514":    fallbackPricing["sonnet"],
+		"claude-opus-4-20250514":      fallbackPricing["opus"],
+	}
+
+	return &PricingCalculator{
+		pricing: pricing,
+	}
+}
+
+// CalculateCost calculates the cost for given token usage and model
+func (pc *PricingCalculator) CalculateCost(
+	model string,
+	inputTokens int,
+	outputTokens int,
+	cacheCreationTokens int,
+	cacheReadTokens int,
+) float64 {
+	// Handle synthetic model
+	if model == "<synthetic>" {
+		return 0.0
+	}
+
+	// Get pricing for model
+	pricing := pc.getPricingForModel(model)
+
+	// Calculate costs (pricing is per million tokens)
+	cost := (float64(inputTokens)/1_000_000)*pricing["input"] +
+		(float64(outputTokens)/1_000_000)*pricing["output"] +
+		(float64(cacheCreationTokens)/1_000_000)*pricing["cache_creation"] +
+		(float64(cacheReadTokens)/1_000_000)*pricing["cache_read"]
+
+	// Round to 6 decimal places
+	return roundToDecimals(cost, 6)
+}
+
+// getPricingForModel gets pricing for a model with fallback logic
+func (pc *PricingCalculator) getPricingForModel(model string) map[string]float64 {
+	// Normalize model name
+	normalized := normalizeModelName(model)
+
+	// Check configured pricing
+	if pricing, exists := pc.pricing[normalized]; exists {
+		return pricing
+	}
+
+	// Check original model name
+	if pricing, exists := pc.pricing[model]; exists {
+		return pricing
+	}
+
+	// Fallback to hardcoded pricing based on model type
+	modelLower := strings.ToLower(model)
+	if strings.Contains(modelLower, "opus") {
+		return pc.pricing["claude-3-opus"]
+	}
+	if strings.Contains(modelLower, "haiku") {
+		return pc.pricing["claude-3-haiku"]
+	}
+	// Default to Sonnet pricing
+	return pc.pricing["claude-3-sonnet"]
+}
+
+// normalizeModelName normalizes model names for consistent lookup
+func normalizeModelName(model string) string {
+	// Remove common prefixes and normalize
+	model = strings.TrimSpace(model)
+	model = strings.ToLower(model)
+	
+	// Map various model name formats to standard names
+	if strings.Contains(model, "opus") {
+		if strings.Contains(model, "4") || strings.Contains(model, "2025") {
+			return "claude-opus-4-20250514"
+		}
+		return "claude-3-opus"
+	}
+	
+	if strings.Contains(model, "haiku") {
+		if strings.Contains(model, "3.5") || strings.Contains(model, "3-5") {
+			return "claude-3-5-haiku"
+		}
+		return "claude-3-haiku"
+	}
+	
+	if strings.Contains(model, "sonnet") {
+		if strings.Contains(model, "4") || strings.Contains(model, "2025") {
+			return "claude-sonnet-4-20250514"
+		}
+		if strings.Contains(model, "3.5") || strings.Contains(model, "3-5") {
+			return "claude-3-5-sonnet"
+		}
+		return "claude-3-sonnet"
+	}
+	
+	return model
+}
+
+// roundToDecimals rounds a float64 to specified decimal places
+func roundToDecimals(num float64, decimals int) float64 {
+	multiplier := 1.0
+	for i := 0; i < decimals; i++ {
+		multiplier *= 10
+	}
+	return float64(int(num*multiplier+0.5)) / multiplier
+}
+
+// CalculateMessageCost calculates cost for a single message
+func (pc *PricingCalculator) CalculateMessageCost(
+	model *string,
+	inputTokens int,
+	outputTokens int,
+	cacheCreationTokens int,
+	cacheReadTokens int,
+) float64 {
+	if model == nil {
+		return 0.0
+	}
+	
+	return pc.CalculateCost(
+		*model,
+		inputTokens,
+		outputTokens,
+		cacheCreationTokens,
+		cacheReadTokens,
+	)
+}

--- a/frontend/components/dashboard-content.tsx
+++ b/frontend/components/dashboard-content.tsx
@@ -122,6 +122,7 @@ export default function Dashboard() {
             plan={displayPlan}
             resetTime={resetTime}
             availableTokens={availableTokenCount}
+            totalCost={tokenUsage.total_cost}
           />
         ) : null}
 

--- a/frontend/components/token-usage-card.tsx
+++ b/frontend/components/token-usage-card.tsx
@@ -10,9 +10,10 @@ interface TokenUsageCardProps {
   plan: string
   resetTime: Date
   availableTokens?: number
+  totalCost?: number
 }
 
-export function TokenUsageCard({ currentUsage, usageLimit, plan, resetTime, availableTokens }: TokenUsageCardProps) {
+export function TokenUsageCard({ currentUsage, usageLimit, plan, resetTime, availableTokens, totalCost }: TokenUsageCardProps) {
   const { t, formatFullDate } = useI18n()
   const usagePercentage = (currentUsage / usageLimit) * 100
   const isNearLimit = usagePercentage > 80
@@ -41,6 +42,13 @@ export function TokenUsageCard({ currentUsage, usageLimit, plan, resetTime, avai
             <div className="text-2xl font-bold">{currentUsage.toLocaleString()}</div>
             <div className="text-sm text-muted-foreground">/ {usageLimit.toLocaleString()} {t('tokenUsage.tokens')}</div>
           </div>
+          
+          {totalCost !== undefined && totalCost > 0 && (
+            <div className="flex items-center justify-between">
+              <div className="text-lg font-semibold text-green-600">${totalCost.toFixed(4)}</div>
+              <div className="text-sm text-muted-foreground">USD (current window)</div>
+            </div>
+          )}
           
           <div className="flex items-center justify-between text-sm text-muted-foreground">
             <span>{t('tokenUsage.available')}: {availableCount.toLocaleString()}{t('tokenUsage.tokens')}</span>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -11,6 +11,7 @@ export interface TokenUsage {
   window_start: string
   window_end: string
   active_sessions: number
+  total_cost: number
 }
 
 export interface Session {


### PR DESCRIPTION
- Implement PricingCalculator with Claude model pricing support
- Add cost calculation to TokenService with window-based aggregation
- Update models to include total_cost fields for sessions and token usage
- Add cost display to frontend TokenUsageCard component
- Update API types to include cost information

Features:
- Support for all Claude models (Opus, Sonnet, Haiku) with accurate pricing
- Cost calculation per session window and individual sessions
- Real-time cost display in the dashboard overview
- Proper handling of cache tokens (creation and read)

🤖 Generated with [Claude Code](https://claude.ai/code)