### PR TITLE
Add message count display functionality to Claudeee

### DIFF
--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -50,6 +50,7 @@ type TokenUsage struct {
 	WindowEnd        time.Time `json:"window_end"`
 	ActiveSessions   int     `json:"active_sessions"`
 	TotalCost        float64 `json:"total_cost"`
+	TotalMessages    int     `json:"total_messages"`
 }
 
 type SessionSummary struct {

--- a/backend/internal/services/token_service.go
+++ b/backend/internal/services/token_service.go
@@ -49,6 +49,7 @@ func (s *TokenService) GetCurrentTokenUsage() (*models.TokenUsage, error) {
 			WindowEnd:      now.Add(WINDOW_DURATION),
 			ActiveSessions: 0,
 			TotalCost:      0.0,
+			TotalMessages:  0,
 		}, nil
 	}
 	
@@ -65,6 +66,7 @@ func (s *TokenService) GetCurrentTokenUsage() (*models.TokenUsage, error) {
 			WindowEnd:      now.Add(WINDOW_DURATION),
 			ActiveSessions: 0,
 			TotalCost:      0.0,
+			TotalMessages:  0,
 		}, nil
 	}
 	
@@ -90,6 +92,7 @@ func (s *TokenService) GetCurrentTokenUsage() (*models.TokenUsage, error) {
 		WindowEnd:      currentWindow.WindowEnd,
 		ActiveSessions: currentWindow.SessionCount,
 		TotalCost:      totalCost,
+		TotalMessages:  currentWindow.MessageCount,
 	}, nil
 }
 

--- a/frontend/components/dashboard-content.tsx
+++ b/frontend/components/dashboard-content.tsx
@@ -123,6 +123,7 @@ export default function Dashboard() {
             resetTime={resetTime}
             availableTokens={availableTokenCount}
             totalCost={tokenUsage.total_cost}
+            totalMessages={tokenUsage.total_messages}
           />
         ) : null}
 

--- a/frontend/components/token-usage-card.tsx
+++ b/frontend/components/token-usage-card.tsx
@@ -11,9 +11,10 @@ interface TokenUsageCardProps {
   resetTime: Date
   availableTokens?: number
   totalCost?: number
+  totalMessages?: number
 }
 
-export function TokenUsageCard({ currentUsage, usageLimit, plan, resetTime, availableTokens, totalCost }: TokenUsageCardProps) {
+export function TokenUsageCard({ currentUsage, usageLimit, plan, resetTime, availableTokens, totalCost, totalMessages }: TokenUsageCardProps) {
   const { t, formatFullDate } = useI18n()
   const usagePercentage = (currentUsage / usageLimit) * 100
   const isNearLimit = usagePercentage > 80
@@ -47,6 +48,13 @@ export function TokenUsageCard({ currentUsage, usageLimit, plan, resetTime, avai
             <div className="flex items-center justify-between">
               <div className="text-lg font-semibold text-green-600">${totalCost.toFixed(4)}</div>
               <div className="text-sm text-muted-foreground">USD</div>
+            </div>
+          )}
+          
+          {totalMessages !== undefined && totalMessages > 0 && (
+            <div className="flex items-center justify-between">
+              <div className="text-lg font-semibold text-blue-600">{totalMessages.toLocaleString()}</div>
+              <div className="text-sm text-muted-foreground">messages (current window)</div>
             </div>
           )}
           

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -12,6 +12,7 @@ export interface TokenUsage {
   window_end: string
   active_sessions: number
   total_cost: number
+  total_messages: number
 }
 
 export interface Session {


### PR DESCRIPTION
- Add total_messages field to TokenUsage model and API
- Update TokenService to include message count from session windows
- Add message count display to TokenUsageCard component
- Update frontend API types to include message count

Features:
- Display current window message count alongside token usage and cost
- Real-time message count tracking in the dashboard overview
- Consistent styling with other metrics (blue color for messages)
- Proper formatting with locale-aware number display

🤖 Generated with [Claude Code](https://claude.ai/code)